### PR TITLE
Support more than one object in events

### DIFF
--- a/hooks/add.sh
+++ b/hooks/add.sh
@@ -15,6 +15,8 @@ else
   type=$(jq -r '.[0].type' ${BINDING_CONTEXT_PATH})
   echo "Event: ${type}"
   if [[ $type == "Event" ]] ; then
-    /engine/add.sh $(jq -r -c '.[0].object' ${BINDING_CONTEXT_PATH})
+    while IFS= read -r object; do
+      /engine/add.sh "$object"
+    done< <(jq -c '.[].object' < ${BINDING_CONTEXT_PATH})
   fi
 fi

--- a/hooks/start-up.sh
+++ b/hooks/start-up.sh
@@ -16,10 +16,12 @@ else
   echo "Event: ${type}"
   if [[ $type == "Synchronization" ]] ; then
     /engine/init-global-database.sh
-    count=$(jq -c '.[0].objects | .[] | .object' ${BINDING_CONTEXT_PATH} | wc -l)
+    count=$(jq -c '.[].objects | .[] | .object' ${BINDING_CONTEXT_PATH} | wc -l)
     if [[ "$count" != "0" ]] ; then
       echo "Synchronizing existing redis databases"
-      jq -c '.[0].objects | .[] | .object' ${BINDING_CONTEXT_PATH} | tr '\n' '\0' | xargs -0 /engine/add.sh
+      while IFS= read -r object; do
+        /engine/add.sh "$object"
+      done< <(jq -c '.[].objects | .[] | .object' < ${BINDING_CONTEXT_PATH})
     fi
   fi
 fi


### PR DESCRIPTION
Upon until this commit, any event that had more than one object in it, only had the first object processed.